### PR TITLE
Add options for zoom and accessibility

### DIFF
--- a/assets/javascripts/initializers/discourse-math.js.es6
+++ b/assets/javascripts/initializers/discourse-math.js.es6
@@ -2,27 +2,25 @@ import { withPluginApi } from 'discourse/lib/plugin-api';
 import loadScript from 'discourse/lib/load-script';
 
 let initializedMathJax = false;
-
-// The site settings are grabbed in the exported initialize function.
-// I'm not sure what the best way to make that variable available to the
-// other functions in the file. I decided to introduce a variable that's
-// local to this file but available accross the file. I'm curious if there's
-// a better approach?
-// Mark McClure, while adding a zoom on click option.
-let file_site_settings;
+let zoom_on_hover, enable_accessibility;
 
 function initMathJax() {
   if (initializedMathJax) { return; }
 
+  var extensions = ["toMathML.js", "Safe.js"];
+  if(enable_accessibility) {
+    extensions.push("[a11y]/accessibility-menu.js")
+  }
   var settings = {
     jax: ['input/TeX', 'input/AsciiMath', 'input/MathML', 'output/CommonHTML'],
     TeX: {extensions: ["AMSmath.js", "AMSsymbols.js", "autoload-all.js"]},
-    extensions: ["toMathML.js"],
+    extensions: extensions,
     showProcessingMessages: false,
     root: '/plugins/discourse-math/mathjax'
   }
-  if(file_site_settings.discourse_math_zoom_on_click) {
-    settings.menuSettings = {zoom:"Click",zscale:"200%"}
+  if(zoom_on_hover) {
+    settings.menuSettings = {zoom: "Hover"};
+    settings.MathEvents = {hover: 750};
   }
   window.MathJax = settings;
   initializedMathJax = true;
@@ -83,7 +81,8 @@ export default {
   name: "apply-math",
   initialize(container) {
     const siteSettings = container.lookup('site-settings:main');
-    file_site_settings = siteSettings;
+    zoom_on_hover = siteSettings.discourse_math_zoom_on_hover;
+    enable_accessibility = siteSettings.discourse_math_enable_accessibility;
     if (siteSettings.discourse_math_enabled) {
       withPluginApi('0.5', initializeMath);
     }

--- a/assets/javascripts/initializers/discourse-math.js.es6
+++ b/assets/javascripts/initializers/discourse-math.js.es6
@@ -3,17 +3,28 @@ import loadScript from 'discourse/lib/load-script';
 
 let initializedMathJax = false;
 
+// The site settings are grabbed in the exported initialize function.
+// I'm not sure what the best way to make that variable available to the
+// other functions in the file. I decided to introduce a variable that's
+// local to this file but available accross the file. I'm curious if there's
+// a better approach?
+// Mark McClure, while adding a zoom on click option.
+let file_site_settings;
+
 function initMathJax() {
   if (initializedMathJax) { return; }
 
-  window.MathJax = {
+  var settings = {
     jax: ['input/TeX', 'input/AsciiMath', 'input/MathML', 'output/CommonHTML'],
     TeX: {extensions: ["AMSmath.js", "AMSsymbols.js", "autoload-all.js"]},
     extensions: ["toMathML.js"],
     showProcessingMessages: false,
     root: '/plugins/discourse-math/mathjax'
-  };
-
+  }
+  if(file_site_settings.discourse_math_zoom_on_click) {
+    settings.menuSettings = {zoom:"Click",zscale:"200%"}
+  }
+  window.MathJax = settings;
   initializedMathJax = true;
 }
 
@@ -72,6 +83,7 @@ export default {
   name: "apply-math",
   initialize(container) {
     const siteSettings = container.lookup('site-settings:main');
+    file_site_settings = siteSettings;
     if (siteSettings.discourse_math_enabled) {
       withPluginApi('0.5', initializeMath);
     }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,3 +4,4 @@
 en:
   site_settings:
     discourse_math_enabled: 'Enable Discourse Math plugin (will add special processing to $ and $$ blocks)'
+    discourse_math_zoom_on_click: 'Zoom 200% on click'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,4 +4,5 @@
 en:
   site_settings:
     discourse_math_enabled: 'Enable Discourse Math plugin (will add special processing to $ and $$ blocks)'
-    discourse_math_zoom_on_click: 'Zoom 200% on click'
+    discourse_math_zoom_on_hover: 'Zoom 200% on hover'
+    discourse_math_enable_accessibility: 'Enable accessibility features'

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -4,4 +4,5 @@
 es:
   site_settings:
     discourse_math_enabled: 'Habilitar plugin Discourse Math (agregará procesamiento especial para los bloques con $ y $$)'
-    discourse_math_zoom_on_click: 'Zoom 200% en el clic'
+    discourse_math_zoom_on_hover: 'Zoom 200% en hover'
+    discourse_math_enable_accessibility: 'Habilitar las funciones de accesibilidad'

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -4,3 +4,4 @@
 es:
   site_settings:
     discourse_math_enabled: 'Habilitar plugin Discourse Math (agregará procesamiento especial para los bloques con $ y $$)'
+    discourse_math_zoom_on_click: 'Zoom 200% en el clic'

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -4,4 +4,5 @@
 fi:
   site_settings:
     discourse_math_enabled: 'Ota käyttöön Discoursen matematiikkalisäosa ($ ja $$ blokit käsitellään erityisellä tavalla)'
-    discourse_math_zoom_on_click: 'Zöömaa 200% näpsäuttämälla'
+    discourse_math_zoom_on_click: 'Zoomaa 200% hoverissa'
+    discourse_math_enable_accessibility: 'Ota käyttöön esteettömyysominaisuudet'

--- a/config/locales/server.fi.yml
+++ b/config/locales/server.fi.yml
@@ -4,3 +4,4 @@
 fi:
   site_settings:
     discourse_math_enabled: 'Ota käyttöön Discoursen matematiikkalisäosa ($ ja $$ blokit käsitellään erityisellä tavalla)'
+    discourse_math_zoom_on_click: 'Zöömaa 200% näpsäuttämälla'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,9 @@ plugins:
   discourse_math_enabled:
     default: false
     client: true
-  discourse_math_zoom_on_click:
+  discourse_math_zoom_on_hover:
+    default: false
+    client: true
+  discourse_math_enable_accessibility:
     default: false
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,6 @@ plugins:
   discourse_math_enabled:
     default: false
     client: true
+  discourse_math_zoom_on_click:
+    default: false
+    client: true


### PR DESCRIPTION
This pull request adds the option to zoom the math output 200% by clicking on it. There are several more options that I would like to add but, as I'm just getting use to GitHub and Discourse Plugin development, I'd like to start with just the one.

I'm pretty confident in the programming but I am a bit curious about the introduction of the `file_site_settings` variable in `discourse-math.js.es6`.