### PR TITLE
Add asciimath processing

### DIFF
--- a/assets/javascripts/initializers/discourse-math.js.es6
+++ b/assets/javascripts/initializers/discourse-math.js.es6
@@ -51,8 +51,6 @@ function decorate(elem, isPreview){
     $elem.after($mathWrapper);
   }
   else if($elem.hasClass('asciimath')) {
-    // const tag = elem.tagName === "DIV" ? "div" : "span";
-    // const display = tag === "div" ? "; mode=display" : "";
     var $mathWrapper = $(`<span style="display: none;"><script type="math/asciimath"></script></span>`);
     var $math = $mathWrapper.children();
     $math.html($elem.text());
@@ -87,24 +85,6 @@ function mathjax($elem) {
       mathElems.each((idx,elem) => decorate(elem, isPreview));
     });
   }
-}
-
-function findProperties(obj) {
-    var aPropertiesAndMethods = [];
-
-    do {
-        aPropertiesAndMethods = aPropertiesAndMethods.concat(Object.getOwnPropertyNames(obj));
-    } while (obj = Object.getPrototypeOf(obj));
-
-    for ( var a = 0; a < aPropertiesAndMethods.length; ++a) {
-        for ( var b = a + 1; b < aPropertiesAndMethods.length; ++b) {
-            if (aPropertiesAndMethods[a] === aPropertiesAndMethods[b]) {
-                aPropertiesAndMethods.splice(a--, 1);
-            }
-        }
-    }
-
-    return aPropertiesAndMethods;
 }
 
 function initializeMath(api) {

--- a/assets/javascripts/initializers/discourse-math.js.es6
+++ b/assets/javascripts/initializers/discourse-math.js.es6
@@ -42,14 +42,22 @@ function decorate(elem, isPreview){
   }
   $elem.data('applied-mathjax', true);
 
-  const tag = elem.tagName === "DIV" ? "div" : "span";
-  const display = tag === "div" ? "; mode=display" : "";
-
-  const $mathWrapper = $(`<${tag} style="display: none;"><script type="math/tex${display}"></script></${tag}>`);
-  const $math = $mathWrapper.children();
-
-  $math.html($elem.text());
-  $elem.after($mathWrapper);
+  if($elem.hasClass('math')) {
+    const tag = elem.tagName === "DIV" ? "div" : "span";
+    const display = tag === "div" ? "; mode=display" : "";
+    var $mathWrapper = $(`<${tag} style="display: none;"><script type="math/tex${display}"></script></${tag}>`);
+    var $math = $mathWrapper.children();
+    $math.html($elem.text());
+    $elem.after($mathWrapper);
+  }
+  else if($elem.hasClass('asciimath')) {
+    // const tag = elem.tagName === "DIV" ? "div" : "span";
+    // const display = tag === "div" ? "; mode=display" : "";
+    var $mathWrapper = $(`<span style="display: none;"><script type="math/asciimath"></script></span>`);
+    var $math = $mathWrapper.children();
+    $math.html($elem.text());
+    $elem.after($mathWrapper);
+  }
 
   Em.run.later(this, ()=> {
     window.MathJax.Hub.Queue(() => {
@@ -70,7 +78,7 @@ function mathjax($elem) {
     return;
   }
 
-  const mathElems = $elem.find('.math');
+  const mathElems = $elem.find('.math, .asciimath');
 
   if (mathElems.length > 0) {
     const isPreview = $elem.hasClass('d-editor-preview');
@@ -79,6 +87,24 @@ function mathjax($elem) {
       mathElems.each((idx,elem) => decorate(elem, isPreview));
     });
   }
+}
+
+function findProperties(obj) {
+    var aPropertiesAndMethods = [];
+
+    do {
+        aPropertiesAndMethods = aPropertiesAndMethods.concat(Object.getOwnPropertyNames(obj));
+    } while (obj = Object.getPrototypeOf(obj));
+
+    for ( var a = 0; a < aPropertiesAndMethods.length; ++a) {
+        for ( var b = a + 1; b < aPropertiesAndMethods.length; ++b) {
+            if (aPropertiesAndMethods[a] === aPropertiesAndMethods[b]) {
+                aPropertiesAndMethods.splice(a--, 1);
+            }
+        }
+    }
+
+    return aPropertiesAndMethods;
 }
 
 function initializeMath(api) {

--- a/assets/javascripts/lib/discourse-markdown/discourse-math.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-math.js.es6
@@ -154,12 +154,16 @@ export function setup(helper) {
     return;
   }
 
+  let enable_asciimath;
   helper.registerOptions((opts, siteSettings) => {
     opts.features.math = siteSettings.discourse_math_enabled;
+    enable_asciimath = siteSettings.discourse_math_enable_asciimath;
   });
 
   helper.registerPlugin(md => {
-    md.inline.ruler.after('escape', 'asciimath', asciiMath);
+    if(enable_asciimath) {
+      md.inline.ruler.after('escape', 'asciimath', asciiMath);
+    }
     md.inline.ruler.after('escape', 'math', inlineMath);
     md.block.ruler.after('code', 'math', blockMath, {
       alt: ['paragraph', 'reference', 'blockquote', 'list']

--- a/assets/javascripts/lib/discourse-markdown/discourse-math.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-math.js.es6
@@ -2,43 +2,44 @@
 //
 //
 //
-function isSafeBoundary(code, md) {
-  if (code === 36) {
+
+function isSafeBoundary(character_code, delimiter_code, md) {
+  if (character_code === delimiter_code) {
     return false;
   }
 
-  if (md.utils.isWhiteSpace(code)) {
+  if (md.utils.isWhiteSpace(character_code)) {
     return true;
   }
 
-  if (md.utils.isMdAsciiPunct(code)) {
+  if (md.utils.isMdAsciiPunct(character_code)) {
     return true;
   }
 
-  if (md.utils.isPunctChar(code)) {
+  if (md.utils.isPunctChar(character_code)) {
     return true;
   }
 
   return false;
 }
 
-function inlineMath(state, silent) {
+function math_input(state, silent, delimiter_code) {
 
   let pos = state.pos,
       posMax = state.posMax;
 
-  if (silent || state.src.charCodeAt(pos) !== 36 /* $ */ || posMax < pos+2) {
+  if (silent || state.src.charCodeAt(pos) !== delimiter_code || posMax < pos+2) {
     return false;
   }
 
   // too short
-  if (state.src.charCodeAt(pos+1) === 36 /* $ */) {
+  if (state.src.charCodeAt(pos+1) === delimiter_code) {
     return false;
   }
 
   if (pos > 0) {
     let prev = state.src.charCodeAt(pos-1);
-    if (!isSafeBoundary(prev, state.md)) {
+    if (!isSafeBoundary(prev, delimiter_code, state.md)) {
       return false;
     }
   }
@@ -47,7 +48,7 @@ function inlineMath(state, silent) {
   let found;
   for(let i=pos+1; i<posMax; i++) {
     let code = state.src.charCodeAt(i);
-    if (code === 36 /* $ */ && state.src.charCodeAt(i-1) !== 92 /* \ */) {
+    if (code === delimiter_code && state.src.charCodeAt(i-1) !== 92 /* \ */) {
       found = i;
       break;
     }
@@ -59,7 +60,7 @@ function inlineMath(state, silent) {
 
   if (found+1 <= posMax) {
     let next = state.src.charCodeAt(found+1);
-    if (next && !isSafeBoundary(next, state.md)) {
+    if (next && !isSafeBoundary(next, delimiter_code, state.md)) {
       return false;
     }
   }
@@ -68,9 +69,18 @@ function inlineMath(state, silent) {
   let token = state.push('html_raw', '', 0);
 
   const escaped = state.md.utils.escapeHtml(data);
-  token.content = `<span class='math'>${escaped}</span>`;
+  let math_class = delimiter_code === 36 ? "'math'" : "'asciimath'";
+  token.content = `<span class=${math_class}>${escaped}</span>`;
   state.pos = found+1;
   return true;
+}
+
+function inlineMath(state, silent) {
+  return math_input(state, silent, 36 /* $ */)
+}
+
+function asciiMath(state, silent) {
+  return math_input(state, silent, 37 /* % */)
 }
 
 function isBlockMarker(state, start, max, md) {
@@ -149,6 +159,7 @@ export function setup(helper) {
   });
 
   helper.registerPlugin(md => {
+    md.inline.ruler.after('escape', 'asciimath', asciiMath);
     md.inline.ruler.after('escape', 'math', inlineMath);
     md.block.ruler.after('code', 'math', blockMath, {
       alt: ['paragraph', 'reference', 'blockquote', 'list']

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,3 +6,4 @@ en:
     discourse_math_enabled: 'Enable Discourse Math plugin (will add special processing to $ and $$ blocks)'
     discourse_math_zoom_on_hover: 'Zoom 200% on hover'
     discourse_math_enable_accessibility: 'Enable accessibility features'
+    discourse_math_enable_asciimath: 'Enable asciimath (will add special processing to % delimited input)'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,3 +8,6 @@ plugins:
   discourse_math_enable_accessibility:
     default: false
     client: true
+  discourse_math_enable_asciimath:
+    default: false
+    client: true


### PR DESCRIPTION
This pull request allows math to be input using [asciimath](http://asciimath.org/). I've chosen to delimit asciimath input using percent symbols. Thus, something like `%int_0^oo e^(-x^2) dx%` should be typeset as intended. I'm open to changing the delimiter but there aren't a lot of choices.

For a brief time, you can see the plugin in action here:
https://discourse.marksmath.org/.
