### PR TITLE
FIX: configure MathJax to use CDN

### DIFF
--- a/assets/javascripts/initializers/discourse-math.js.es6
+++ b/assets/javascripts/initializers/discourse-math.js.es6
@@ -19,7 +19,7 @@ function initMathJax(opts) {
     TeX: { extensions: ["AMSmath.js", "AMSsymbols.js", "autoload-all.js"] },
     extensions: extensions,
     showProcessingMessages: false,
-    root: "/plugins/discourse-math/mathjax"
+    root: Discourse.getURLWithCDN("/plugins/discourse-math/mathjax")
   };
 
   if (opts.zoom_on_hover) {


### PR DESCRIPTION
Came across this when testing CSP.

I tested the change locally to make sure the option `root` works with a full URL.

<img src="https://user-images.githubusercontent.com/6376558/48869108-ff1ac300-eda9-11e8-99fb-15e48fbe55e8.png" width="500px"/>

Note, [the MathJax fonts](https://github.com/discourse/discourse-math/tree/master/public/mathjax/fonts/HTML-CSS/TeX) will also be loaded over the the CDN, will be any CORS issues?  @SamSaffron 

