### PR TITLE
FEATURE: Responsive equations

### DIFF
--- a/assets/javascripts/initializers/discourse-math-katex.js.es6
+++ b/assets/javascripts/initializers/discourse-math-katex.js.es6
@@ -22,7 +22,7 @@ function decorate(elem) {
 
   if ($elem.hasClass("math")) {
     const text = $elem.text();
-    $elem.text("");
+    $elem.addClass("math-container").text("");
     window.katex.render(text, elem, { displayMode });
   }
 }

--- a/assets/javascripts/initializers/discourse-math-mathjax.js.es6
+++ b/assets/javascripts/initializers/discourse-math-mathjax.js.es6
@@ -49,14 +49,14 @@ function decorate(elem, isPreview) {
     const tag = elem.tagName === "DIV" ? "div" : "span";
     const display = tag === "div" ? "; mode=display" : "";
     $mathWrapper = $(
-      `<${tag} style="display: none;"><script type="math/tex${display}"></script></${tag}>`
+      `<${tag} class="math-container" style="display: none;"><script type="math/tex${display}"></script></${tag}>`
     );
     $math = $mathWrapper.children();
     $math.text($elem.text());
     $elem.after($mathWrapper);
   } else if ($elem.hasClass("asciimath")) {
     $mathWrapper = $(
-      `<span style="display: none;"><script type="math/asciimath"></script></span>`
+      `<span class="math-container" style="display: none;"><script type="math/asciimath"></script></span>`
     );
     $math = $mathWrapper.children();
     $math.text($elem.text());

--- a/assets/stylesheets/common/discourse-math.scss
+++ b/assets/stylesheets/common/discourse-math.scss
@@ -1,0 +1,59 @@
+.math-container {
+  display: block;
+
+  > div:nth-child(2),
+  > span:nth-child(2),
+  > .katex-display {
+    // Mathjax ships with !important inline;
+    display: block !important;
+    max-width: 100%;
+    margin-bottom: 1em;
+
+    // Inner containers for all renderers
+    > :first-child:not(.katex),
+    .katex-html {
+      display: block;
+      overflow: auto hidden;
+      max-width: 100%;
+      padding: 0.25em 0.5em;
+      box-sizing: border-box;
+    }
+  }
+
+  // On mobile we add a slight fade on either side to indicate that the user can
+  // scroll. However, this should not be added to the composer since mathjax does
+  // not render in the mobile composer
+  .cooked & {
+    .mobile-view & {
+      position: relative;
+      &:before {
+        content: "";
+        position: absolute;
+        z-index: 1;
+        left: 0;
+        top: 0;
+        width: 1em;
+        height: 100%;
+        background: linear-gradient(
+          to right,
+          rgba($secondary, 1) 0%,
+          rgba($secondary, 0) 100%
+        );
+      }
+      &:after {
+        content: "";
+        position: absolute;
+        z-index: 1;
+        right: 0;
+        top: 0;
+        width: 1em;
+        height: 100%;
+        background: linear-gradient(
+          to right,
+          rgba($secondary, 0) 0%,
+          rgba($secondary, 1) 100%
+        );
+      }
+    }
+  }
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -6,4 +6,6 @@
 # authors: Sam Saffron (sam)
 # url: https://github.com/discourse/discourse-math
 
+register_asset "stylesheets/common/discourse-math.scss"
+
 enabled_site_setting :discourse_math_enabled


### PR DESCRIPTION
context: https://meta.discourse.org/t/discourse-math-plugin/65770/137

This PR adds styles that allow equations to be responsive. This has been tested with both MathJax and Katex. MathJax testing includes all the different renderers. 

*  HTML-CSS
*  Common HTML
*  Preview HTML 
*  MathML
*  SVG
*  Plain Source

This has also been tested with Asciimath on all 6 renders above. 

Wide equations will now behave like this on desktop

https://d11a6trkgmumsb.cloudfront.net/original/3X/a/1/a1d8e2785d538069aa7b3051028cc109ed454ebf.mp4 

and like this on mobile

https://d11a6trkgmumsb.cloudfront.net/original/3X/0/3/03aa3ca7e2dd43d3ab45d11c4c6864dfc86fc6b5.mp4 

The videos above demonstrate the behaviour for all equations regardless of the math provider and the renderer. They will all behave like that.

On mobile, the PR adds a slight fade on either side to indicate that the user can scroll if the equation is wide.
