### PR TITLE
WIP: FEATURE: custom inline and block math delimiters

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/discourse-math.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/discourse-math.js.es6
@@ -72,7 +72,7 @@ let inlineMath = (startDelimiter, endDelimiter) => (state, silent) => {
 
   if (found + endDelimiter.length <= posMax) {
     let next = state.src[found + endDelimiter.length];
-    if (!isSafeBoundary(next, endDelimiter)) {
+    if (next && !isSafeBoundary(next, endDelimiter)) {
       return false;
     }
   }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,5 +8,6 @@ en:
     discourse_math_zoom_on_hover: 'Zoom 200% on hover (MathJax only)'
     discourse_math_enable_accessibility: 'Enable accessibility features (MathJax only)'
     discourse_math_enable_asciimath: 'Enable asciimath (will add special processing to % delimited input) (MathJax only)'
-    discourse_math_inline_delimiters: 'You can have multiple delimiters for inline math, but each must be single character'
-    discourse_math_block_delimiters: 'You can have multiple delimiters for block math. Delimiters starting with "\begin{" will be passed to the LaTeX engine and are expected to end with the corresponding \end{} command'
+    discourse_math_inline_delimiters: 'You can have multiple delimiters for inline math'
+    discourse_math_block_delimiters: 'You can have multiple delimiters for block math. Delimiters starting with "\begin{}" will be passed to the LaTeX engine and should to end with the corresponding \end{} command'
+    discourse_math_process_tex_environments: 'Enable processing of "\begin{*}...\end{*}" environments (MathJax only)'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,3 +8,5 @@ en:
     discourse_math_zoom_on_hover: 'Zoom 200% on hover (MathJax only)'
     discourse_math_enable_accessibility: 'Enable accessibility features (MathJax only)'
     discourse_math_enable_asciimath: 'Enable asciimath (will add special processing to % delimited input) (MathJax only)'
+    discourse_math_inline_delimiters: 'You can have multiple delimiters for inline math, but each must be single character'
+    discourse_math_block_delimiters: 'You can have multiple delimiters for block math. Delimiters starting with "\begin{" will be passed to the LaTeX engine and are expected to end with the corresponding \end{} command'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,15 +10,16 @@ plugins:
       - mathjax
       - katex
   discourse_math_inline_delimiters:
-    default: '$'
+    default: '$,$'
     client: true
     type: list
-    list_type: compact
   discourse_math_block_delimiters:
-    default: '$$|\\begin{align}'
+    default: '$$,$$'
     client: true
     type: list
-    list_type: compact
+  discourse_math_process_tex_environments:
+    default: false
+    client: true
   discourse_math_zoom_on_hover:
     default: false
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,16 @@ plugins:
     choices:
       - mathjax
       - katex
+  discourse_math_inline_delimiters:
+    default: '$'
+    client: true
+    type: list
+    list_type: compact
+  discourse_math_block_delimiters:
+    default: '$$|\\begin{align}'
+    client: true
+    type: list
+    list_type: compact
   discourse_math_zoom_on_hover:
     default: false
     client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # name: discourse-math
-# about: Official mathjax plugin for Discourse
+# about: Official LaTeX plugin for Discourse
 # version: 0.9
 # authors: Sam Saffron (sam)
 # url: https://github.com/discourse/discourse-math


### PR DESCRIPTION
Per several user requests, this PR adds two new settings for users to specify custom (possibly multiple) math delimiters. Note that users using the [old plugin](https://github.com/kasperpeulen/discourse-mathjax) have no good way to upgrade without this functionality.

The new code also handles things like `\begin{align}...\end{align}`. These must be treated as a special case because they need to be passed to MathJax.

Here's my test code:
```latex
Inline math $E=mc^2$  and inline math with custom delimiter `!`  !E=mc^3!

ascii math %E=mc^2%

Default Block Math
$$
E=mc^2
$$

Custom block math with `$$$`
$$$
E=mc^2
$$$

Custom block math starting with `\begin{align}`
\begin{align}
\hat{H}\Psi &= E \Psi \\
\hat{H_i}\Psi_i &= E_i \Psi
\end{align}
```

And here's how it looks:

--- 

![image](https://user-images.githubusercontent.com/9539441/76152087-d3fdd500-60bb-11ea-981d-4a58164d7749.png)

---
(note that the \begin{align} does what it's supposed to do, i.e. align multiple equations on `=`)


**TODO / TO DISCUSS:**
 - ~~The current approach does not allow for different delimiters for beginning and end, such as `\[ display \]`. If we want to support all [that's out there](https://github.com/cben/mathdown/wiki/math-in-markdown#markdown-preview-plus-chrome-extension), we should allow this.~~ DONE :heavy_check_mark: 

 - The current code only allows for single-character inline math delimiters (because that's how it was written originally), but one of standard TeX syntax for inline math is `\( inline \)` so we should allow this.

- Instead of requiring admins to insert every `\begin{*}...\end{*}` environment they want to support, we could have a switch to process every block math of this form. This would be MathJaX only, KaTeX does not support these, although it [might in near future](https://github.com/KaTeX/KaTeX/pull/2183). DONE: :heavy_check_mark: 
