### PR TITLE
DEV: adds chat support

### DIFF
--- a/assets/stylesheets/ext/discourse-chat.scss
+++ b/assets/stylesheets/ext/discourse-chat.scss
@@ -1,0 +1,12 @@
+.chat-message-text {
+  // huge selector complexity/specificity makes it hard to do differently
+  // this is done to limit the size of the chat message after MathJax has rendered
+  // ultimately we would want a better solution to avoid channel jumpyness
+  // topics suffer from the same issue
+  .MJXc-display,
+  .MathJax_CHTML {
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+  }
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,5 +8,10 @@
 # transpile_js: true
 
 register_asset "stylesheets/common/discourse-math.scss"
+register_asset "stylesheets/ext/discourse-chat.scss"
 
 enabled_site_setting :discourse_math_enabled
+
+after_initialize do
+  chat&.enable_markdown_feature("discourse-math") if respond_to?(:chat) && SiteSetting.chat_enabled
+end


### PR DESCRIPTION
This commit is also removing jquery code and simplifying code.

Note that discourse-math is currently causing jumpy-ness in topics or in chat as the resulting processed mathjax element has a different size than the initial text node.