### PR TITLE
FIX: ensures chat is present/enabled

### DIFF
--- a/assets/javascripts/initializers/discourse-math-mathjax.js
+++ b/assets/javascripts/initializers/discourse-math-mathjax.js
@@ -116,14 +116,16 @@ function initializeMath(api, discourseMathOptions) {
     { id: "mathjax" }
   );
 
-  api.decorateChatMessage(
-    (element) => {
-      mathjax(element, discourseMathOptions);
-    },
-    {
-      id: "mathjax-chat",
-    }
-  );
+  if (api.decorateChatMessage) {
+    api.decorateChatMessage(
+      (element) => {
+        mathjax(element, discourseMathOptions);
+      },
+      {
+        id: "mathjax-chat",
+      }
+    );
+  }
 }
 
 export default {


### PR DESCRIPTION
Without this when chat is disabled the API is not supercharged with these methods and it will cause an exception:

```
Uncaught (in promise) TypeError: t.decorateChatMessage is not a function
    initialize discourse-math-mathjax.js:102
    initialize discourse-math-mathjax.js:119
    withPluginApi discourse-f7231bd5d10aa613b323a0cac71d8003baa74ef74f674fe4f91e4857994e661b.br.js:4735
    initialize discourse-math-mathjax.js:118
    initialize discourse-f7231bd5d10aa613b323a0cac71d8003baa74ef74f674fe4f91e4857994e661b.br.js:67
    runInstanceInitializers Ember
    each dag-map.js:192
    walk dag-map.js:121
    each dag-map.js:66
    topsort dag-map.js:72
    Ember 4
    invoke queue.ts:201
    flush queue.ts:98
    flush deferred-action-queues.ts:75
    _end index.ts:616
    _boundAutorunEnd index.ts:257
discourse-math-mathjax.js:102
```