### PR TITLE
FIX: prevents inline span to be forced into blocks

### DIFF
--- a/assets/javascripts/initializers/discourse-math-mathjax.js
+++ b/assets/javascripts/initializers/discourse-math-mathjax.js
@@ -78,7 +78,7 @@ function decorate(elem, isPreview) {
         if (elem?.parentElement?.offsetParent !== null) {
           window.MathJax.Hub.Typeset(mathScript, () => {
             elem.style.display = "none";
-            mathWrapper.style.display = "block";
+            mathWrapper.style.display = null;
           });
         }
       });


### PR DESCRIPTION
Prior to this fix the "block" style would be used on any node (block or inline).