### PR TITLE
UX: Hide mathjax loading toast

### DIFF
--- a/assets/javascripts/initializers/discourse-math-mathjax.js
+++ b/assets/javascripts/initializers/discourse-math-mathjax.js
@@ -21,6 +21,7 @@ function initMathJax(opts) {
     TeX: { extensions: ["AMSmath.js", "AMSsymbols.js", "autoload-all.js"] },
     extensions,
     showProcessingMessages: false,
+    messageStyle: "none",
     root: getURLWithCDN("/plugins/discourse-math/mathjax"),
   };
 


### PR DESCRIPTION
it's this thing:

<img width="285" alt="Screenshot 2024-02-05 at 12 20 18" src="https://github.com/discourse/discourse-math/assets/66961/3df2b23e-1cfd-44c5-b515-c738fd9ec5d6">
