### PR TITLE
FIX: prefers textContent over innerText

### DIFF
--- a/assets/javascripts/initializers/discourse-math-mathjax.js
+++ b/assets/javascripts/initializers/discourse-math-mathjax.js
@@ -61,7 +61,7 @@ function decorate(elem, isPreview) {
 
   const mathScript = document.createElement("script");
   mathScript.type = type;
-  mathScript.innerText = elem.innerText;
+  mathScript.innerText = elem.textContent;
 
   const mathWrapper = document.createElement(tag);
   mathWrapper.classList.add(classList.split(" "));

--- a/spec/system/post_spec.rb
+++ b/spec/system/post_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe "Discourse Math - post", type: :system do
+  fab!(:current_user) { Fabricate(:admin) }
+
+  before do
+    SiteSetting.discourse_math_enabled = true
+    sign_in(current_user)
+  end
+
+  it "works with details" do
+    post =
+      create_post(
+        user: current_user,
+        raw: "This is maths:\n\n[details='math']\n$E=mc^2$\n[/details]",
+      )
+    visit(post.topic.url)
+
+    find("#post_1 details").click
+
+    expect(page).to have_selector("#MJXc-Node-6", text: "2")
+  end
+end


### PR DESCRIPTION
`textContent` should work for hidden content (in details for example) when `innerText` will return an empty string.